### PR TITLE
Package.json: Fix JSON and use node v0.10.38

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
     "license": "MIT",
     "setupPhantom": true,
     "engines": {
-        "node": "0.12.2",
-        "bugs": {
-            "url": "https://github.com/NewsResources/outilsjournaliste/issues",
-            "homepage": "https://github.com/NewsResources/outilsjournaliste"
-        }
+        "node": "0.10.38"
+    },
+    "bugs": {
+        "url": "https://github.com/NewsResources/outilsjournaliste/issues",
+        "homepage": "https://github.com/NewsResources/outilsjournaliste"
+    }
+}


### PR DESCRIPTION
Cette PR fix le package.json et dit à NPM d'utiliser node v0.10.38, je n'ai pas réussi à installer avec node v0.12.2 (comme beaucoup de choses)
